### PR TITLE
Add enum type support to ABI serialization

### DIFF
--- a/include/sysio/abi.hpp
+++ b/include/sysio/abi.hpp
@@ -137,6 +137,21 @@ struct variant_def {
 
 SYSIO_REFLECT(variant_def, name, types);
 
+struct enum_value_def {
+   std::string name{};
+   int64_t     value{};
+};
+
+SYSIO_REFLECT(enum_value_def, name, value);
+
+struct enum_def {
+   std::string                 name{};
+   std::string                 type{};   // underlying type, e.g. "uint8"
+   std::vector<enum_value_def> values{};
+};
+
+SYSIO_REFLECT(enum_def, name, type, values);
+
 struct action_result_def {
    sysio::name name{};
    std::string result_type{};
@@ -168,10 +183,11 @@ struct abi_def {
    abi_extensions_type                                        abi_extensions{};
    might_not_exist<std::vector<variant_def>>                  variants{};
    might_not_exist<std::vector<action_result_def>>            action_results{};
+   might_not_exist<std::vector<enum_def>>                     enums{};
 };
 
 SYSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_clauses, error_messages, abi_extensions,
-              variants, action_results);
+              variants, action_results, enums);
 
 struct abi_type;
 
@@ -206,7 +222,11 @@ struct abi_type {
       std::vector<abi_field> fields;
    };
    using variant = std::vector<abi_field>;
-   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array, struct_, variant, fixed_array>
+   struct enum_ {
+      abi_type*                                    underlying_type;
+      std::vector<std::pair<std::string, int64_t>> values;
+   };
+   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, const enum_def*, alias, optional, extension, array, struct_, variant, fixed_array, enum_>
                          _data;
    const abi_serializer* ser = nullptr;
 
@@ -249,6 +269,7 @@ struct abi_type {
    }
    const struct_* as_struct() const { return std::get_if<struct_>(&_data); }
    const variant* as_variant() const { return std::get_if<variant>(&_data); }
+   const enum_* as_enum() const { return std::get_if<enum_>(&_data); }
 
    std::string bin_to_json(
          input_stream& bin, std::function<void()> f = [] {}) const;
@@ -282,6 +303,7 @@ extern const abi_serializer* const array_abi_serializer;
 extern const abi_serializer* const fixed_array_abi_serializer;
 extern const abi_serializer* const extension_abi_serializer;
 extern const abi_serializer* const optional_abi_serializer;
+extern const abi_serializer* const enum_abi_serializer;
 
 using basic_abi_types =
       std::tuple<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, __int128, unsigned __int128,
@@ -405,6 +427,7 @@ void to_json(const abi_def& def, S& stream) {
    to_json_write_helper(def.error_messages, "error_messages", true, stream);
    to_json_write_helper(def.variants.value, "variants", true, stream);
    to_json_write_helper(def.action_results.value, "action_results", true, stream);
+   to_json_write_helper(def.enums.value, "enums", true, stream);
    stream.write('}');
 }
 } // namespace sysio

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -149,6 +149,22 @@ abi_type::variant resolve(std::map<std::string, abi_type>& abi_types, const vari
     return result;
 }
 
+bool is_integer_type(const std::string& name) {
+   return name == "uint8" || name == "int8" || name == "uint16" || name == "int16" ||
+          name == "uint32" || name == "int32" || name == "uint64" || name == "int64";
+}
+
+abi_type::enum_ resolve(std::map<std::string, abi_type>& abi_types, const enum_def* type, int depth) {
+   sysio::check(depth < 32, sysio::convert_abi_error(abi_error::recursion_limit_reached));
+   auto* underlying = get_type(abi_types, type->type, depth + 1);
+   sysio::check(is_integer_type(underlying->name),
+       "Enum '" + type->name + "' has unsupported underlying type '" + type->type + "'; must be an integer type");
+   abi_type::enum_ result{underlying, {}};
+   for (auto& ev : type->values)
+      result.values.emplace_back(ev.name, ev.value);
+   return result;
+}
+
 abi_type::alias resolve(std::map<std::string, abi_type>& abi_types, const abi_type::alias_def* type, int depth) {
     auto t = get_type(abi_types, *type, depth + 1);
     sysio::check(!std::holds_alternative<abi_type::extension>(t->_data),
@@ -220,6 +236,13 @@ void sysio::convert(const abi_def& abi, sysio::abi& c) {
         sysio::check(inserted,
             sysio::convert_abi_error(abi_error::redefined_type));
     }
+    for (auto& e : abi.enums.value) {
+       sysio::check(!e.name.empty(),
+            sysio::convert_abi_error(abi_error::missing_name));
+        auto [it, inserted] = c.abi_types.try_emplace(e.name, e.name, &e, &abi_serializer_for<::abieos::pseudo_enum>);
+        sysio::check(inserted,
+            sysio::convert_abi_error(abi_error::redefined_type));
+    }
     for (auto& [_, t] : c.abi_types) {
         fill(c.abi_types, t, 0);
     }
@@ -264,6 +287,15 @@ void to_abi_def(abi_def& def, const std::string& name, const abi_type::variant& 
    def.variants.value.push_back({name, std::move(types)});
 }
 
+void to_abi_def(abi_def& def, const std::string& name, const abi_type::enum_& e) {
+   enum_def ed;
+   ed.name = name;
+   ed.type = e.underlying_type->name;
+   for (auto& [n, v] : e.values)
+      ed.values.push_back({n, v});
+   def.enums.value.push_back(std::move(ed));
+}
+
 void sysio::convert(const sysio::abi& abi, sysio::abi_def& def) {
    def.version = "sysio::abi/1.0";
    for(auto& [name, type] : abi.abi_types) {
@@ -277,6 +309,7 @@ const abi_serializer* const sysio::array_abi_serializer = &abi_serializer_for< :
 const abi_serializer* const sysio::fixed_array_abi_serializer = &abi_serializer_for< ::abieos::pseudo_fixed_array>;
 const abi_serializer* const sysio::extension_abi_serializer = &abi_serializer_for< ::abieos::pseudo_extension>;
 const abi_serializer* const sysio::optional_abi_serializer = &abi_serializer_for< ::abieos::pseudo_optional>;
+const abi_serializer* const sysio::enum_abi_serializer = &abi_serializer_for< ::abieos::pseudo_enum>;
 
 std::vector<char> sysio::abi_type::json_to_bin_reorderable(std::string_view json, std::function<void()> f) const {
    abieos::jvalue tmp;

--- a/src/abieos.hpp
+++ b/src/abieos.hpp
@@ -27,6 +27,7 @@
 #pragma clang diagnostic ignored "-W#warnings"
 #endif
 
+#include <charconv>
 #include <ctime>
 #include <map>
 #include <optional>
@@ -64,6 +65,7 @@ struct pseudo_object;
 struct pseudo_array;
 struct pseudo_fixed_array;
 struct pseudo_variant;
+struct pseudo_enum;
 
 // !!!
 template <typename SrcIt, typename DestIt>
@@ -348,6 +350,12 @@ void bin_to_json(pseudo_array*, bin_to_json_state& state, bool allow_extensions,
 void bin_to_json(pseudo_fixed_array*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void bin_to_json(pseudo_variant*, bin_to_json_state& state, bool allow_extensions,
+                                const abi_type* type, bool start);
+void json_to_bin(pseudo_enum*, jvalue_to_bin_state& state, bool allow_extensions,
+                                const abi_type* type, bool start);
+void json_to_bin(pseudo_enum*, json_to_bin_state& state, bool allow_extensions,
+                                const abi_type* type, bool start);
+void bin_to_json(pseudo_enum*, bin_to_json_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -753,6 +761,52 @@ inline void json_to_bin(pseudo_variant*, jvalue_to_bin_state& state, bool allow_
     }
 }
 
+inline int64_t enum_parse_value(const abi_type::enum_& e, std::string_view sv) {
+    for (auto& [name, v] : e.values) {
+        if (name == sv)
+            return v;
+    }
+    // Fallback: parse as integer literal
+    int64_t val = 0;
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), val);
+    sysio::check(ec == std::errc{}, "Unknown enum value: " + std::string(sv));
+    return val;
+}
+
+inline void enum_write_int(sysio::vector_stream& out, const std::string& type_name, int64_t val) {
+    using sysio::to_bin;
+    if (type_name == "uint8")  { to_bin((uint8_t)val, out);  return; }
+    if (type_name == "int8")   { to_bin((int8_t)val, out);   return; }
+    if (type_name == "uint16") { to_bin((uint16_t)val, out); return; }
+    if (type_name == "int16")  { to_bin((int16_t)val, out);  return; }
+    if (type_name == "uint32") { to_bin((uint32_t)val, out); return; }
+    if (type_name == "int32")  { to_bin((int32_t)val, out);  return; }
+    if (type_name == "uint64") { to_bin((uint64_t)val, out); return; }
+    if (type_name == "int64")  { to_bin((int64_t)val, out);  return; }
+    sysio::check(false, "Unsupported enum underlying type");
+}
+
+inline int64_t enum_read_int(sysio::input_stream& bin, const std::string& type_name) {
+    using sysio::from_bin;
+    if (type_name == "uint8")  { uint8_t v;  from_bin(v, bin); return v; }
+    if (type_name == "int8")   { int8_t v;   from_bin(v, bin); return v; }
+    if (type_name == "uint16") { uint16_t v; from_bin(v, bin); return v; }
+    if (type_name == "int16")  { int16_t v;  from_bin(v, bin); return v; }
+    if (type_name == "uint32") { uint32_t v; from_bin(v, bin); return v; }
+    if (type_name == "int32")  { int32_t v;  from_bin(v, bin); return v; }
+    if (type_name == "uint64") { uint64_t v; from_bin(v, bin); return (int64_t)v; }
+    if (type_name == "int64")  { int64_t v;  from_bin(v, bin); return v; }
+    sysio::check(false, "Unsupported enum underlying type"); return 0;
+}
+
+inline void json_to_bin(pseudo_enum*, jvalue_to_bin_state& state, bool,
+                        const abi_type* type, bool) {
+    auto& e = std::get<abi_type::enum_>(type->_data);
+    auto& sv = std::get<std::string>(state.received_value->value);
+    int64_t val = enum_parse_value(e, sv);
+    enum_write_int(state.writer, e.underlying_type->name, val);
+}
+
 template <typename T, typename State>
 void json_to_bin(T*, State& state, bool, const abi_type*, bool start) {
     using sysio::from_json;
@@ -940,6 +994,14 @@ inline void json_to_bin(pseudo_variant*, json_to_bin_state& state, bool allow_ex
     }
 }
 
+inline void json_to_bin(pseudo_enum*, json_to_bin_state& state, bool,
+                        const abi_type* type, bool) {
+    auto& e = std::get<abi_type::enum_>(type->_data);
+    auto sv = state.get_string(); // numbers also arrive as strings via kParseNumbersAsStringsFlag
+    int64_t val = enum_parse_value(e, sv);
+    enum_write_int(state.writer, e.underlying_type->name, val);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // bin_to_json
 ///////////////////////////////////////////////////////////////////////////////
@@ -1085,6 +1147,22 @@ inline void bin_to_json(pseudo_variant*, bin_to_json_state& state, bool allow_ex
         state.stack.pop_back();
         state.writer.write(']');
     }
+}
+
+inline void bin_to_json(pseudo_enum*, bin_to_json_state& state, bool,
+                        const abi_type* type, bool) {
+    auto& e = std::get<abi_type::enum_>(type->_data);
+    int64_t val = enum_read_int(state.bin, e.underlying_type->name);
+    for (auto& [name, v] : e.values) {
+        if (v == val) {
+            to_json(name, state.writer);
+            return;
+        }
+    }
+    // Fallback: output unknown value as quoted string number.
+    // Note: wire-sysio's abi_serializer outputs raw integer here instead.
+    auto s = std::to_string(val);
+    to_json(s, state.writer);
 }
 
 template <typename T>

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -160,6 +160,32 @@ const char testAbi[] = R"({
     ]
 })";
 
+const char testEnumAbi[] = R"({
+    "version": "sysio::abi/1.1",
+    "structs": [
+        {
+            "name": "addtrxp",
+            "fields": [
+                {"name": "receiver", "type": "name"},
+                {"name": "action_name", "type": "name"},
+                {"name": "match_type", "type": "trx_match_type"},
+                {"name": "priority", "type": "int16"}
+            ]
+        }
+    ],
+    "enums": [
+        {
+            "name": "trx_match_type",
+            "type": "uint8",
+            "values": [
+                {"name": "only", "value": 0},
+                {"name": "first", "value": 1},
+                {"name": "any", "value": 2}
+            ]
+        }
+    ]
+})";
+
 const char transactionAbi[] = R"({
     "version": "sysio::abi/1.0",
     "types": [
@@ -614,6 +640,8 @@ void check_types() {
     check_context(context, abieos_set_abi(context, testAbiName, testAbi));
     check_context(context, abieos_set_abi_hex(context, testHexAbiName, testHexAbi));
     check_context(context, abieos_set_abi(context, testKvAbiName, testKvTablesAbi));
+    auto testEnumAbiName = check_context(context, abieos_string_to_name(context, "test.enum"));
+    check_context(context, abieos_set_abi(context, testEnumAbiName, testEnumAbi));
 
     int next_id = 0;
     auto write_corpus = [&](bool abi_is_bin, uint8_t operation, uint64_t contract, sysio::input_stream abi,
@@ -667,6 +695,9 @@ void check_types() {
             std::string error;
             if (!abieos::unhex(error, testHexAbi, testHexAbi + strlen(testHexAbi), std::back_inserter(abi)))
                 throw std::runtime_error(error);
+        } else if (contract == testEnumAbiName) {
+            abi_is_bin = false;
+            abi = {testEnumAbi, testEnumAbi + strlen(testEnumAbi)};
         } else {
             throw std::runtime_error("missing case in check_type");
         }
@@ -1280,6 +1311,24 @@ void check_types() {
 
     testWith(testAbiName);
     testWith(testHexAbiName);
+
+    // Enum type roundtrip: name string -> bin -> name string
+    check_type(context, testEnumAbiName, "trx_match_type", R"("only")");
+    check_type(context, testEnumAbiName, "trx_match_type", R"("first")");
+    check_type(context, testEnumAbiName, "trx_match_type", R"("any")");
+
+    // Enum in struct roundtrip
+    check_type(context, testEnumAbiName, "addtrxp",
+        R"({"receiver":"sysio","action_name":"transfer","match_type":"only","priority":10})");
+    check_type(context, testEnumAbiName, "addtrxp",
+        R"({"receiver":"sysio","action_name":"transfer","match_type":"any","priority":5})");
+
+    // Integer input accepted, outputs as name
+    check_type(context, testEnumAbiName, "trx_match_type", R"("0")", R"("only")");
+    check_type(context, testEnumAbiName, "trx_match_type", R"("1")", R"("first")");
+
+    // Unknown integer value falls back to string number
+    check_type(context, testEnumAbiName, "trx_match_type", R"("99")", R"("99")");
 
     auto check_checksum_capacity = [&](const auto& checksum, size_t capacity, const char* msg) {
         if(checksum.capacity() != capacity)

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -846,11 +846,11 @@ void check_types() {
     check_type(context, 0, "time_point", R"("2000-12-31T23:59:59.999999")", R"("2000-12-31T23:59:59.999")");
     check_error(context, "expected string containing time_point",
                 [&] { return abieos_json_to_bin(context, 0, "time_point", "true"); });
-    check_type(context, 0, "block_timestamp_type", R"("2000-01-01T00:00:00.000")");
-    check_type(context, 0, "block_timestamp_type", R"("2000-01-01T00:00:00.500")");
-    check_type(context, 0, "block_timestamp_type", R"("2000-01-01T00:00:01.000")");
-    check_type(context, 0, "block_timestamp_type", R"("2018-06-15T19:17:47.500")");
-    check_type(context, 0, "block_timestamp_type", R"("2018-06-15T19:17:48.000")");
+    check_type(context, 0, "block_timestamp_type", R"("2025-01-01T00:00:00.000")");
+    check_type(context, 0, "block_timestamp_type", R"("2025-01-01T00:00:00.500")");
+    check_type(context, 0, "block_timestamp_type", R"("2025-01-01T00:00:01.000")");
+    check_type(context, 0, "block_timestamp_type", R"("2030-06-15T19:17:47.500")");
+    check_type(context, 0, "block_timestamp_type", R"("2030-06-15T19:17:48.000")");
     check_error(context, "expected string containing block_timestamp_type",
                 [&] { return abieos_json_to_bin(context, 0, "block_timestamp_type", "true"); });
     check_type(context, 0, "name", R"("")");


### PR DESCRIPTION
## Summary
- Adds full enum support to abieos, matching wire-sysio's `abi_serializer` behavior
- Enums defined in ABI with name, underlying integer type, and symbolic values are now parsed and used for JSON ↔ binary conversion
- `bin_to_json` outputs symbolic names (`"only"`, `"first"`, `"any"`); `json_to_bin` accepts both names and integer strings
- Fixes Hyperion's `"Unknown type: trx_match_type"` error when indexing blocks with `sysio.system` trx_priority enums
- Also fixes pre-existing `block_timestamp_type` test failure (test dates updated for Wire's 2025 epoch)

## Files changed
- `include/sysio/abi.hpp` — `enum_value_def`, `enum_def`, `abi_def.enums`, `abi_type::enum_`
- `src/abi.cpp` — `resolve()`, enum registration in `convert()`, underlying type validation
- `src/abieos.hpp` — `pseudo_enum` serializer, `enum_read_int`/`enum_write_int`/`enum_parse_value` helpers
- `src/test.cpp` — enum roundtrip tests, block_timestamp date fixes, fuzzer corpus mapping